### PR TITLE
Bump Dax.Vpax.Obfuscator version 0.3.3-beta

### DIFF
--- a/src/Dax.Vpax.Obfuscator.CLI/Dax.Vpax.Obfuscator.CLI.csproj
+++ b/src/Dax.Vpax.Obfuscator.CLI/Dax.Vpax.Obfuscator.CLI.csproj
@@ -8,12 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dax.Vpax.Obfuscator" />
     <PackageReference Include="System.CommandLine" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Dax.Vpax.Obfuscator.Common\Dax.Vpax.Obfuscator.Common.csproj" />
-    <ProjectReference Include="..\Dax.Vpax.Obfuscator\Dax.Vpax.Obfuscator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageVersion Include="Dax.Vpax" Version="1.4.0" />
+    <PackageVersion Include="Dax.Vpax.Obfuscator" Version="0.3.3-beta" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <!-- Global package references -->


### PR DESCRIPTION
Notes:
Add package reference to `Dax.Vpax.Obfuscator` instead of using a project reference.
