### PR TITLE
Rename dictionary file extension to `.vpax.dict`

### DIFF
--- a/src/Dax.Vpax.Obfuscator.TestApp/Form1.Designer.cs
+++ b/src/Dax.Vpax.Obfuscator.TestApp/Form1.Designer.cs
@@ -90,8 +90,8 @@
             // 
             // openDictionaryFileDialog
             // 
-            openDictionaryFileDialog.DefaultExt = "*.dictionary.json";
-            openDictionaryFileDialog.Filter = "Obfucator Dictionary file|*.dictionary.json";
+            openDictionaryFileDialog.DefaultExt = "*.vpax.dict";
+            openDictionaryFileDialog.Filter = "Obfucator Dictionary file|*.vpax.dict";
             // 
             // buttonDeobfuscate
             // 

--- a/src/Dax.Vpax.Obfuscator.TestApp/Form1.cs
+++ b/src/Dax.Vpax.Obfuscator.TestApp/Form1.cs
@@ -77,7 +77,7 @@ namespace Dax.Vpax.Obfuscator.TestApp
                 ? obfuscator.Obfuscate(stream, ObfuscationDictionary.ReadFrom(dictionaryFile.FullName))
                 : obfuscator.Obfuscate(stream);
 
-            var dictionaryPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".dictionary.json"));
+            var dictionaryPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".vpax.dict"));
             var vpaxPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".obfuscated.vpax"));
 
             dictionary.WriteTo(dictionaryPath, overwrite: checkBoxOverwriteDictionary.Checked, indented: true);


### PR DESCRIPTION
Applies only to WinForm test app
