### PR TITLE
Add public API to enable obf/deobf of a `Dax.Metadata.Model` object

### DIFF
--- a/src/Dax.Vpax.Obfuscator/IVpaxObfuscator.cs
+++ b/src/Dax.Vpax.Obfuscator/IVpaxObfuscator.cs
@@ -1,26 +1,38 @@
-﻿using Dax.Vpax.Obfuscator.Common;
+﻿using Dax.Metadata;
+using Dax.Vpax.Obfuscator.Common;
 
 namespace Dax.Vpax.Obfuscator;
 
 public interface IVpaxObfuscator
 {
     /// <summary>
-    /// Obfuscate the DaxModel.json file and delete all other contents from the provided VPAX stream.
+    /// Obfuscate the DaxModel.json file and delete all other contents from the <paramref name="stream"/>.
     /// </summary>
     /// <param name="stream">The VPAX stream</param>
-    /// <returns>The obfuscation dictionary</returns>
+    /// <returns>The obfuscation dictionary generated from the obfuscation process</returns>
     ObfuscationDictionary Obfuscate(Stream stream);
 
     /// <summary>
-    /// Obfuscate the DaxModel.json file and delete all other contents from the provided VPAX stream.
+    /// Obfuscate the <paramref name="model"/>.
     /// </summary>
-    /// <remarks>
-    /// This method updates the obfuscation dictionary to changes applied since a previous obfuscation.
-    /// </remarks>
+    /// <returns>The obfuscation dictionary generated from the obfuscation process</returns>
+    ObfuscationDictionary Obfuscate(Model model);
+
+    /// <summary>
+    /// Incrementally obfuscate the DaxModel.json file and delete all other contents from the <paramref name="stream"/>.
+    /// </summary>
     /// <param name="stream">The VPAX stream</param>
     /// <param name="dictionary">The obfuscation dictionary generated from a previous obfuscation</param>
-    /// <returns>The obfuscation dictionary updated to changes applied since a previous obfuscation.</returns>
+    /// <returns>The obfuscation <paramref name="dictionary"/> updated to changes applied since a previous obfuscation.</returns>
     ObfuscationDictionary Obfuscate(Stream stream, ObfuscationDictionary dictionary);
+
+    /// <summary>
+    /// Incrementally obfuscate the <paramref name="model"/>.
+    /// </summary>
+    /// <param name="stream">The VPAX stream</param>
+    /// <param name="dictionary">The obfuscation dictionary generated from a previous obfuscation</param>
+    /// <returns>The obfuscation <paramref name="dictionary"/> updated to changes applied since a previous obfuscation.</returns>
+    ObfuscationDictionary Obfuscate(Model model, ObfuscationDictionary dictionary);
 
     /// <summary>
     /// Deobfuscate the DaxModel.json file using the provided obfuscation dictionary.
@@ -28,4 +40,11 @@ public interface IVpaxObfuscator
     /// <param name="stream">The VPAX stream</param>
     /// <param name="dictionary">The obfuscation dictionary</param>
     void Deobfuscate(Stream stream, ObfuscationDictionary dictionary);
+
+    /// <summary>
+    /// Deobfuscate the <paramref name="model"/> using the provided obfuscation dictionary.
+    /// </summary>
+    /// <param name="stream">The VPAX stream</param>
+    /// <param name="dictionary">The obfuscation dictionary</param>
+    void Deobfuscate(Model model, ObfuscationDictionary dictionary);
 }


### PR DESCRIPTION
Introduce a public API to facilitate obfuscation and deobfuscation of a `Dax.Metadata.Model` object, eliminating the need for the VPAX file stream.