### PR TITLE
Bump Dax.Vpax.Obfuscator version 0.6.2-beta

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageVersion Include="Dax.Vpax" Version="1.4.1" />
-    <PackageVersion Include="Dax.Vpax.Obfuscator" Version="0.3.3-beta" />
+    <PackageVersion Include="Dax.Vpax.Obfuscator" Version="0.6.2-beta" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <!-- Global package references -->


### PR DESCRIPTION
Closes #[issue number]

## Description
-

Notes:
