### PR TITLE
Fix `VpaxObfuscator.Version` to use semantic versioning

### DIFF
--- a/src/Dax.Vpax.Obfuscator/VpaxObfuscator.cs
+++ b/src/Dax.Vpax.Obfuscator/VpaxObfuscator.cs
@@ -7,7 +7,7 @@ namespace Dax.Vpax.Obfuscator;
 
 public sealed class VpaxObfuscator : IVpaxObfuscator
 {
-    public static string Version { get; } = ThisAssembly.AssemblyInformationalVersion;
+    public static string Version { get; } = System.Version.Parse(ThisAssembly.AssemblyFileVersion).ToString(3);
     public ObfuscationOptions Options { get; } = new();
 
     public ObfuscationDictionary Obfuscate(Stream stream, ObfuscationDictionary? dictionary = null) => ObfuscateImpl(Options, stream, dictionary);


### PR DESCRIPTION
Closes #[issue number]

## Description
-

Notes:
