### PR TITLE
Add TryGet* methods to ObfuscationDictionary, enable NuGet publish

### DIFF
--- a/.github/workflows/release-obfuscator-common.yml
+++ b/.github/workflows/release-obfuscator-common.yml
@@ -25,7 +25,9 @@ jobs:
     - name: dotnet pack
       run: dotnet pack -c Release 'src/${{ env.PROJECT }}/${{ env.PROJECT }}.csproj'
     - name: nuget push
-      run: echo "::warning::(TOFIX) enable nuget push."
+      run: dotnet nuget push '${{ env.NUPKG_PATH }}' -k '${{ secrets.NUGET_API_KEY }}' -s https://api.nuget.org/v3/index.json 
+      env:
+        NUPKG_PATH: 'src/artifacts/package/release/${{ env.PROJECT }}.${{ steps.nbgv.outputs.NuGetPackageVersion }}.nupkg'
     - name: create release
       run: |
         PRERELEASE_FLAG=$([[ "${{ steps.nbgv.outputs.PrereleaseVersion }}" != "" ]] && echo "--prerelease" || echo "")

--- a/src/Dax.Vpax.Obfuscator.Common/Dax.Vpax.Obfuscator.Common.csproj
+++ b/src/Dax.Vpax.Obfuscator.Common/Dax.Vpax.Obfuscator.Common.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
     <Title>Vpax Obfuscator Common</Title>
-    <Description>A shared package used by VertiPaq Analyzer Obfuscator. Do not install this package manually, it will be added as a prerequisite by other packages that require it.</Description>
+    <Description>This package is a dependency for the VertiPaq Analyzer Obfuscator NuGet package and is automatically included as a prerequisite. It should not be installed manually.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
+++ b/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace Dax.Vpax.Obfuscator.Common;
@@ -26,6 +27,7 @@ public sealed class ObfuscationDictionary
         Id = id;
         Version = version;
         Texts = texts.OrderBy((t) => t.Value).ToArray();
+        UnobfuscatedValues = Array.Empty<string>();
 
         // Create dictionaries to enable fast lookups and ensure key uniqueness. An error will be thrown if duplicate keys are detected.
         _values = Texts.ToDictionary((text) => text.Value, StringComparer.OrdinalIgnoreCase);
@@ -35,7 +37,7 @@ public sealed class ObfuscationDictionary
     public string Id { get; }
     public string Version { get; }
     public IReadOnlyList<ObfuscationText> Texts { get; }
-    public IReadOnlyList<string>? UnobfuscatedValues { get; }
+    public IReadOnlyList<string> UnobfuscatedValues { get; }
 
     public string GetValue(string obfuscated)
     {

--- a/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
+++ b/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
@@ -27,7 +27,7 @@ public sealed class ObfuscationDictionary
         Version = version;
         Texts = texts.OrderBy((t) => t.Value).ToArray();
 
-        // Create dictionaries to allow for fast lookups. This also ensures uniqueness of the keys by throwing if there are duplicates.
+        // Create dictionaries to enable fast lookups and ensure key uniqueness. An error will be thrown if duplicate keys are detected.
         _values = Texts.ToDictionary((text) => text.Value, StringComparer.OrdinalIgnoreCase);
         _obfuscated = Texts.ToDictionary((text) => text.Obfuscated, StringComparer.OrdinalIgnoreCase);
     }
@@ -45,12 +45,36 @@ public sealed class ObfuscationDictionary
         throw new KeyNotFoundException($"The obfuscated value was not found in the dictionary [{obfuscated}].");
     }
 
+    public bool TryGetValue(string obfuscated, [NotNullWhen(true)] out string? value)
+    {
+        if (_obfuscated.TryGetValue(obfuscated, out var text))
+        {
+            value = text.Value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
     public string GetObfuscated(string value)
     {
         if (_values.TryGetValue(value, out var text))
             return text.Obfuscated;
 
         throw new KeyNotFoundException($"The value was not found in the dictionary [{value}].");
+    }
+
+    public bool TryGetObfuscated(string value, [NotNullWhen(true)] out string? obfuscated)
+    {
+        if (_values.TryGetValue(value, out var text))
+        {
+            obfuscated = text.Obfuscated;
+            return true;
+        }
+
+        obfuscated = null;
+        return false;
     }
 
     public void WriteTo(string path, bool overwrite = false, bool indented = true)

--- a/src/Dax.Vpax.Obfuscator.TestApp/Form1.cs
+++ b/src/Dax.Vpax.Obfuscator.TestApp/Form1.cs
@@ -108,22 +108,22 @@ namespace Dax.Vpax.Obfuscator.TestApp
                 : obfuscator.Obfuscate(stream);
 
             var dictionaryPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".vpax.dict"));
-            var vpaxPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".obfuscated.vpax"));
+            var ovpaxPath = Path.Combine(outputPath, Path.ChangeExtension(vpaxFile.Name, ".ovpax"));
 
             dictionary.WriteTo(dictionaryPath, overwrite, indented: true);
-            File.WriteAllBytes(vpaxPath, stream.ToArray());
+            File.WriteAllBytes(ovpaxPath, stream.ToArray());
         }
 
-        private static void Deobfuscate(FileInfo vpaxFile, FileInfo dictionaryFile)
+        private static void Deobfuscate(FileInfo ovpaxFile, FileInfo dictionaryFile)
         {
-            var data = File.ReadAllBytes(vpaxFile.FullName);
+            var data = File.ReadAllBytes(ovpaxFile.FullName);
             using var stream = new MemoryStream();
             stream.Write(data, 0, data.Length);
 
             var obfuscator = new VpaxObfuscator();
             obfuscator.Deobfuscate(stream, ObfuscationDictionary.ReadFrom(dictionaryFile.FullName));
 
-            var vpaxPath = Path.Combine(vpaxFile.DirectoryName!, Path.ChangeExtension(vpaxFile.Name, ".deobfuscated.vpax"));
+            var vpaxPath = Path.Combine(ovpaxFile.DirectoryName!, Path.ChangeExtension(ovpaxFile.Name, ".deobfuscated.vpax"));
             File.WriteAllBytes(vpaxPath, stream.ToArray());
         }
     }


### PR DESCRIPTION
- Add `TryGetValue` and `TryGetObfuscated` methods to `ObfuscationDictionary`, ensuring safer lookups. 
- Make the `UnobfuscatedValues` property non-nullable.
- Enable publishing of the Common NuGet package.