### PR TITLE
Fix to load unobfuscated values during dictionary deserialization

### DIFF
--- a/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
+++ b/src/Dax.Vpax.Obfuscator.Common/ObfuscationDictionary.cs
@@ -9,16 +9,8 @@ public sealed class ObfuscationDictionary
     private readonly Dictionary<string, ObfuscationText> _values;
     private readonly Dictionary<string, ObfuscationText> _obfuscated;
 
-    public ObfuscationDictionary(string id, string version, IEnumerable<ObfuscationText> texts, IEnumerable<string> unobfuscatedValues)
-        : this(id, version, texts)
-    {
-        if (unobfuscatedValues == null) throw new ArgumentNullException(nameof(unobfuscatedValues));
-
-        UnobfuscatedValues = unobfuscatedValues.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-    }
-
     [JsonConstructor]
-    public ObfuscationDictionary(string id, string version, IEnumerable<ObfuscationText> texts)
+    public ObfuscationDictionary(string id, string version, IEnumerable<ObfuscationText> texts, IEnumerable<string> unobfuscatedValues)
     {
         if (id == null || !Guid.TryParseExact(id, "D", out var guid) || guid == Guid.Empty) throw new ArgumentException("The dictionary identifier is not valid.", nameof(id));
         if (version == null) throw new ArgumentNullException(nameof(version));
@@ -27,7 +19,7 @@ public sealed class ObfuscationDictionary
         Id = id;
         Version = version;
         Texts = texts.OrderBy((t) => t.Value).ToArray();
-        UnobfuscatedValues = Array.Empty<string>();
+        UnobfuscatedValues = unobfuscatedValues?.ToArray() ?? [];
 
         // Create dictionaries to enable fast lookups and ensure key uniqueness. An error will be thrown if duplicate keys are detected.
         _values = Texts.ToDictionary((text) => text.Value, StringComparer.OrdinalIgnoreCase);

--- a/src/Dax.Vpax.Obfuscator/DaxModelObfuscator.cs
+++ b/src/Dax.Vpax.Obfuscator/DaxModelObfuscator.cs
@@ -48,10 +48,9 @@ internal sealed partial class DaxModelObfuscator
         var id = Model.ObfuscatorDictionaryId;
         var version = VpaxObfuscator.Version;
         var texts = Texts.Select((t) => t.ToObfuscationText());
+        var unobfuscatedValues = Options.TrackUnobfuscated ? UnobfuscatedValues.Distinct(StringComparer.OrdinalIgnoreCase) : [];
 
-        return Options.TrackUnobfuscated
-            ? new ObfuscationDictionary(id, version, texts, UnobfuscatedValues)
-            : new ObfuscationDictionary(id, version, texts);
+        return new ObfuscationDictionary(id, version, texts, unobfuscatedValues);
     }
 
     private void ObfuscateIdentifiers(Table table)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/tests/Dax.Vpax.Obfuscator.Common.Tests/ObfuscationDictionaryTests.cs
+++ b/tests/Dax.Vpax.Obfuscator.Common.Tests/ObfuscationDictionaryTests.cs
@@ -7,14 +7,15 @@ public class ObfuscationDictionaryTests
     [Fact]
     public void ctor_EmptyTexts_ReturnsEmptyDictionary()
     {
-        var dictionary = new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts: []);
+        var dictionary = new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts: [], unobfuscatedValues: []);
         Assert.Empty(dictionary.Texts);
+        Assert.Empty(dictionary.UnobfuscatedValues);
     }
 
     [Fact]
     public void ctor_EmptyId_Throws()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new ObfuscationDictionary(id: Guid.Empty.ToString("D"), "0.0.0-test", texts: []));
+        var exception = Assert.Throws<ArgumentException>(() => new ObfuscationDictionary(id: Guid.Empty.ToString("D"), "0.0.0-test", texts: [], unobfuscatedValues: []));
         Assert.StartsWith("The dictionary identifier is not valid.", exception.Message);
     }
 
@@ -27,7 +28,7 @@ public class ObfuscationDictionaryTests
             new ObfuscationText("VALUE", "XXXXXX"),
         };
 
-        var exception = Assert.Throws<ArgumentException>(() => new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts));
+        var exception = Assert.Throws<ArgumentException>(() => new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts, unobfuscatedValues: []));
         Assert.StartsWith("An item with the same key has already been added.", exception.Message);
     }
 
@@ -128,6 +129,6 @@ public class ObfuscationDictionaryTests
 
     private static ObfuscationDictionary CreateDictionary(ObfuscationText[] texts)
     {
-        return new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts);
+        return new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", texts, unobfuscatedValues: []);
     }
 }

--- a/tests/Dax.Vpax.Obfuscator.Tests/DaxModelObfuscatorTests.cs
+++ b/tests/Dax.Vpax.Obfuscator.Tests/DaxModelObfuscatorTests.cs
@@ -521,7 +521,7 @@ public class DaxModelObfuscatorTests
     private static DaxModelDeobfuscator CreateDeobfuscator(IEnumerable<DaxText> texts)
     {
         var obfuscationTexts = texts.Select((t) => t.ToObfuscationText()).ToArray();
-        var dictionary = new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", obfuscationTexts);
+        var dictionary = new ObfuscationDictionary(id: Guid.NewGuid().ToString("D"), "0.0.0-test", obfuscationTexts, unobfuscatedValues: []);
         return CreateDeobfuscator(dictionary);
     }
 


### PR DESCRIPTION
Always load unobfuscated values during dictionary deserialization