### PR TITLE
Switch to package reference for Dax.Vpax.Obfuscator.Common

### DIFF
--- a/src/Dax.Tokenizer/DaxToken.cs
+++ b/src/Dax.Tokenizer/DaxToken.cs
@@ -15,7 +15,7 @@ namespace Dax.Tokenizer
         /// <summary>
         /// Get the next token
         /// </summary>
-        public DaxToken Prev
+        public DaxToken? Prev
         {
             get
             {
@@ -30,7 +30,7 @@ namespace Dax.Tokenizer
             }
         }
 
-        public DaxToken Next
+        public DaxToken? Next
         {
             get
             {

--- a/src/Dax.Tokenizer/DaxTokenizer.cs
+++ b/src/Dax.Tokenizer/DaxTokenizer.cs
@@ -1,5 +1,6 @@
 ﻿using Antlr4.Runtime;
 
+[assembly: CLSCompliant(false)]
 namespace Dax.Tokenizer
 {
     public static class DaxTokenizer

--- a/src/Dax.Vpax.Obfuscator.TestApp/Dax.Vpax.Obfuscator.TestApp.csproj
+++ b/src/Dax.Vpax.Obfuscator.TestApp/Dax.Vpax.Obfuscator.TestApp.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dax.Vpax.Obfuscator.Common\Dax.Vpax.Obfuscator.Common.csproj" />
     <ProjectReference Include="..\Dax.Vpax.Obfuscator\Dax.Vpax.Obfuscator.csproj" />
   </ItemGroup>
 

--- a/src/Dax.Vpax.Obfuscator/Dax.Vpax.Obfuscator.csproj
+++ b/src/Dax.Vpax.Obfuscator/Dax.Vpax.Obfuscator.csproj
@@ -26,13 +26,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dax.Vpax.Obfuscator.Common\Dax.Vpax.Obfuscator.Common.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Dax.Tokenizer\Dax.Tokenizer.csproj" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Dax.Vpax" Version="1.6.0" />
+    <PackageReference Include="Dax.Vpax.Obfuscator.Common" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,37 +42,21 @@
   <!-- Include DLL from project reference in NuGet package -->
   <ItemGroup>
     <!-- net462 -->
-    <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net462\Dax.Vpax.Obfuscator.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\net462\</PackagePath>
-    </_PackageFiles>
     <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net462\Dax.Tokenizer.dll">
       <BuildAction>None</BuildAction>
       <PackagePath>lib\net462\</PackagePath>
     </_PackageFiles>
     <!-- netcoreapp3.1 -->
-    <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_netcoreapp3.1\Dax.Vpax.Obfuscator.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\netcoreapp3.1\</PackagePath>
-    </_PackageFiles>
     <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_netcoreapp3.1\Dax.Tokenizer.dll">
       <BuildAction>None</BuildAction>
       <PackagePath>lib\netcoreapp3.1\</PackagePath>
     </_PackageFiles>
     <!-- net6.0 -->
-    <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net6.0\Dax.Vpax.Obfuscator.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\net6.0\</PackagePath>
-    </_PackageFiles>
     <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net6.0\Dax.Tokenizer.dll">
       <BuildAction>None</BuildAction>
       <PackagePath>lib\net6.0\</PackagePath>
     </_PackageFiles>
     <!-- net8.0 -->
-    <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net8.0\Dax.Vpax.Obfuscator.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\net8.0\</PackagePath>
-    </_PackageFiles>
     <_PackageFiles Include="$(OutputPath.TrimEnd('\').TrimEnd('/'))_net8.0\Dax.Tokenizer.dll">
       <BuildAction>None</BuildAction>
       <PackagePath>lib\net8.0\</PackagePath>

--- a/tests/Dax.Vpax.Obfuscator.Tests/Dax.Vpax.Obfuscator.Tests.csproj
+++ b/tests/Dax.Vpax.Obfuscator.Tests/Dax.Vpax.Obfuscator.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Dax.Vpax.Obfuscator.Common\Dax.Vpax.Obfuscator.Common.csproj" />
     <ProjectReference Include="..\..\src\Dax.Vpax.Obfuscator\Dax.Vpax.Obfuscator.csproj" />
     <ProjectReference Include="..\..\src\Dax.Tokenizer\Dax.Tokenizer.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Replaced project reference to `Dax.Vpax.Obfuscator.Common` with a package reference in `Dax.Vpax.Obfuscator.csproj` for better dependency management