### PR TITLE
Add obfuscation support for `Table.DefaultDetailRowsExpression` 

### DIFF
--- a/src/Dax.Vpax.Obfuscator/Dax.Vpax.Obfuscator.csproj
+++ b/src/Dax.Vpax.Obfuscator/Dax.Vpax.Obfuscator.csproj
@@ -31,7 +31,7 @@
   
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Dax.Vpax" Version="1.6.0" />
+    <PackageReference Include="Dax.Vpax" Version="1.8.0" />
     <PackageReference Include="Dax.Vpax.Obfuscator.Common" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/Dax.Vpax.Obfuscator/DaxModelDeobfuscator.cs
+++ b/src/Dax.Vpax.Obfuscator/DaxModelDeobfuscator.cs
@@ -31,6 +31,7 @@ internal partial class DaxModelDeobfuscator
     {
         DeobfuscateTableName(table.TableName);
         Deobfuscate(table.TableExpression);
+        Deobfuscate(table.DefaultDetailRowsExpression);
         Deobfuscate(table.CalculationGroup);
         Deobfuscate(table.Description);
         table.Columns.ForEach(Deobfuscate);

--- a/src/Dax.Vpax.Obfuscator/DaxModelObfuscator.cs
+++ b/src/Dax.Vpax.Obfuscator/DaxModelObfuscator.cs
@@ -96,6 +96,7 @@ internal sealed partial class DaxModelObfuscator
     private void Obfuscate(Table table)
     {
         Obfuscate(table.TableExpression);
+        Obfuscate(table.DefaultDetailRowsExpression);
         Obfuscate(table.CalculationGroup);
         Obfuscate(table.Description);
         table.Columns.ForEach(Obfuscate);

--- a/src/Dax.Vpax.Obfuscator/version.json
+++ b/src/Dax.Vpax.Obfuscator/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "nugetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
Add obfuscation support for `Table.DefaultDetailRowsExpression` introduced in Vpax 1.8.0